### PR TITLE
Support Fullscreen Companion Window, Fullscreen Capability Delegation, screen swapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,7 @@ window.addEventListener('load', () => {
   window.addEventListener('message', handleWindowMessage);
 
   // Handle control button clicks and input events.
-  openWindowButton.addEventListener('click', () => { openWindow(null); });
-  openWindowControls.addEventListener('keyup', (e) => { if (e.key === "Enter") openWindow(null); });
+  openWindowButton.addEventListener('click', openWindow);
   updateScreensButton.addEventListener('click', updateScreens);
   // openWindowsButton.addEventListener('click', openWindows);
   toggleFullscreenButton.addEventListener('click', toggleFullscreen);

--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@ window.addEventListener('load', () => {
   window.addEventListener('message', handleWindowMessage);
 
   // Handle control button clicks and input events.
-  openWindowButton.addEventListener('click', openWindow);
-  openWindowControls.addEventListener('keyup', (e) => { if (e.key === "Enter") openWindow(); });
+  openWindowButton.addEventListener('click', () => { openWindow(null); });
+  openWindowControls.addEventListener('keyup', (e) => { if (e.key === "Enter") openWindow(null); });
   updateScreensButton.addEventListener('click', updateScreens);
   // openWindowsButton.addEventListener('click', openWindows);
   toggleFullscreenButton.addEventListener('click', toggleFullscreen);

--- a/main.js
+++ b/main.js
@@ -2,8 +2,11 @@
 
 let permissionStatus = null;
 let screenDetails = null;
+let popup = null;
+let popupObserverInterval = null;
 
 function showWarning(text) {
+  const warning = document.getElementById('warning');
   if (text && (warning.innerHTML !== text || warning.hidden))
     console.error(text);
   if (warning) {
@@ -24,13 +27,15 @@ window.addEventListener('load', async () => {
   updateScreens(/*requestPermission=*/false);
 });
 
+window.addEventListener('keyup', handleWindowKeyup);
+
 function setScreenListeners() {
   let screens = screenDetails ? screenDetails.screens : [ window.screen ];
   for (const s of screens)
     s.onchange = () => { updateScreens(/*requestPermission=*/false); };
 }
 
-async function getScreenDetailsWithWarningAndFallback(requestPermission) {
+async function getScreenDetailsWithWarningAndFallback(requestPermission = false) {
   if ('getScreens' in self || 'getScreenDetails' in self) {
     if (!screenDetails && ((permissionStatus && permissionStatus.state === 'granted') ||
                            (permissionStatus && permissionStatus.state === 'prompt' && requestPermission))) {
@@ -118,7 +123,8 @@ async function showScreens(screens) {
 
 async function updateScreens(requestPermission = true) {
   const screens = await getScreenDetailsWithWarningAndFallback(requestPermission);
-  showScreens(screens);
+  if (document.getElementById('screensCanvas'))
+    showScreens(screens);
 
   if (document.getElementById('toggleFullscreenDropdown')) {
     toggleFullscreenDropdown.innerHTML = ``;
@@ -138,7 +144,7 @@ async function updateScreens(requestPermission = true) {
   if (document.getElementById('fullscreenOpenerDropdown')) {
     fullscreenOpenerDropdown.innerHTML = ``;
     for (let i = 0; i < screens.length; ++i)
-      fullscreenOpenerDropdown.innerHTML += screens[i] == window.screen ? `` : `<button onclick="fullscreenOpener(${i})"> Screen ${i}</button>`;
+      fullscreenOpenerDropdown.innerHTML += screens[i] == window.screen ? `` : `<button onclick="fullscreenOpenerAndMoveThisPopup(${i})"> Screen ${i}</button>`;
   }
   return screens;
 }
@@ -148,22 +154,36 @@ function getFeaturesFromOptions(options) {
          ",width=" + options.width + ",height=" + options.height;
 }
 
-function openWindow() {
-  const url = openWindowUrlInput.value;
-  const options = {
-    x: openWindowLeftInput.value,
-    y: openWindowTopInput.value,
-    width: openWindowWidthInput.value,
-    height: openWindowHeightInput.value,
-  };
-  // TODO: Support openWindow(options) if available.
-  window.open(url, '_blank', getFeaturesFromOptions(options));
+function openWindow(options = null) {
+  if (!options) {
+    options = {
+      url: openWindowUrlInput.value,
+      x: openWindowLeftInput.value,
+      y: openWindowTopInput.value,
+      width: openWindowWidthInput.value,
+      height: openWindowHeightInput.value,
+    };
+  }
+  if (popupObserverInterval)
+    clearInterval(popupObserverInterval);
+  const features = getFeaturesFromOptions(options);
+  console.log('INFO: Opening popup with features: ' + features);
+  popup = window.open(options.url, '_blank', features);
+  popupObserverInterval = setInterval(() => {
+    if (popup.closed) {
+      console.log('INFO: The latest popup opened was closed');
+      clearInterval(popupObserverInterval);
+      popupObserverInterval = null;
+      popup = null;
+    }
+  }, 300);
+  return popup;
 }
 
 // TODO: Add some worthwhile multi-window opening example?
 // async function openWindows() {
 //   let count = openWindowsCountInput.value;
-//   const screens = await updateScreens(/*requestPermission=*/false);
+//   const screens = await getScreenDetailsWithWarningAndFallback();
 //   const per_screen = Math.ceil(count / screens.length);
 //   console.log(`openWindows count:${count}, screens:${screens.length}, per_screen:${per_screen}`);
 //   for (const s of screens) {
@@ -186,7 +206,7 @@ function openWindow() {
 // }
 
 async function toggleElementFullscreen(element, screenId) {
-  const screens = await updateScreens(/*requestPermission=*/false);
+  const screens = await getScreenDetailsWithWarningAndFallback();
   if (Number.isInteger(screenId) && screenId >= 0 && screenId < screens.length) {
     console.log('INFO: Requesting fullscreen on screen: ' + screenId);
     await element.requestFullscreen({ screen: screens[screenId] });
@@ -204,57 +224,43 @@ async function toggleFullscreen(screenId) {
 }
 
 async function openSlideWindow(screenId) {
-  const screens = await updateScreens(/*requestPermission=*/false);
+  const screens = await getScreenDetailsWithWarningAndFallback();
   let options = { x:screen.availLeft, y:screen.availTop,
                   width:screen.availWidth, height:screen.availHeight/2 };
-  if (screens && screens.length > 1) {
+  if (screens.length > 1) {
     let screen = screens[1];
     if (Number.isInteger(screenId) && screenId >= 0 && screenId < screens.length)
       screen = screens[screenId];
     options = { x:screen.availLeft, y:screen.availTop,
                 width:screen.availWidth, height:screen.availHeight };
   }
-  const features = getFeaturesFromOptions(options);
-  // TODO: Re-enable and use the fullscreen feature string option?
-  console.log('INFO: Opening window with feature string: ' + features);
-  const slide_window = window.open('./slide.html', '_blank', features);
-  // TODO: Make the window fullscreen; this doesn't currently work:
-  // slide_window.document.body.requestFullscreen();
-  // TODO: Open another window or reposition the current window.
-  // window.open('./notes.html', '_blank', getFeaturesFromOptions(options));
-  return slide_window;
+  options.url = './slide.html';
+  return openWindow(options);
 }
 
 async function openNotesWindow(screenId) {
-  const screens = await updateScreens(/*requestPermission=*/false);
+  const screens = await getScreenDetailsWithWarningAndFallback();
   let options = { x:screen.availLeft, y:screen.availTop+screen.availHeight/2,
                   width:screen.availWidth, height:screen.availHeight/2 };
-  if (screens && screens.length > 1) {
+  if (screens.length > 1) {
     let screen = screens[0];
     if (Number.isInteger(screenId) && screenId >= 0 && screenId < screens.length)
       screen = screens[screenId];
     options = { x:screen.availLeft, y:screen.availTop,
                 width:screen.availWidth, height:screen.availHeight };
   }
-  const features = getFeaturesFromOptions(options);
-  // TODO: Re-enable and use the fullscreen feature string option?
-  console.log('INFO: Opening window with feature string: ' + features);
-  const notes_window = window.open('./notes.html', '_blank', features);
-  // TODO: Make the window fullscreen; this doesn't currently work:
-  // notes_window.document.body.requestFullscreen();
-  // TODO: Open another window or reposition the current window.
-  // window.open('./slide.html', '_blank', getFeaturesFromOptions(options));
-  return notes_window;
+  options.url = './notes.html';
+  return openWindow(options);
 }
 
 async function openSlideAndNotesWindows() {
-  const slides_window = await openSlideWindow();
-  const notes_window = await openNotesWindow();
-  if (slides_window && notes_window) {
+  const slideWindow = await openSlideWindow();
+  const notesWindow = await openNotesWindow();
+  if (slideWindow && notesWindow) {
     const interval = setInterval(() => {
-      if (slides_window.closed || notes_window.closed) {
-        slides_window.close();
-        notes_window.close();
+      if (slideWindow.closed || notesWindow.closed) {
+        slideWindow.close();
+        notesWindow.close();
         clearInterval(interval);
       }
     }, 300);
@@ -266,32 +272,195 @@ async function fullscreenSlide(screenId) {
 }
 
 async function fullscreenSlideAndOpenNotesWindow(screenId) {
+  const screens = await getScreenDetailsWithWarningAndFallback();
   if (!Number.isInteger(screenId) || screenId < 0 || screenId >= screens.length)
     screenId = 0;
   await fullscreenSlide(screenId);
-  const notes_window = await openNotesWindow(screenId == 0 ? 1 : 0);
-  if (notes_window) {
+  const notesWindow = await openNotesWindow(screenId == 0 ? 1 : 0);
+  if (notesWindow) {
     const interval = setInterval(() => {
-      if (!document.fullscreenElement && !notes_window.closed) {
-        notes_window.close();
+      if (!document.fullscreenElement && !notesWindow.closed) {
+        console.log("MSW fullscreenSlideAndOpenNotesWindow interval close"); 
+        // notesWindow.close(); 
         clearInterval(interval);
-      } else if (notes_window.closed && document.fullscreenElement) {
+      } else if (notesWindow.closed && document.fullscreenElement) {
         document.exitFullscreen();
         clearInterval(interval);
       }
     }, 300);
   }
+  console.log("MSW popup: " + popup); 
 }
 
 async function handleWindowMessage(messageEvent) {
+  console.log("MSW handleWindowMessage"); 
   const messageData = messageEvent.data.split(":");
-  if (messageData[0] === "request-fullscreen" && messageData.length == 2)
-    toggleFullscreen(parseInt(messageData[1]));
+  if (messageData[0] === "request-fullscreen" && messageData.length == 2) {
+    const element = document.fullscreenElement ? document.fullscreenElement : document.documentElement;
+    await toggleElementFullscreen(element, parseInt(messageData[1]));
+  }
 }
 
-async function fullscreenOpener(screenId) {
-  // Capability Delegation allows a frame to delegate its transient user
-  // activation so another frame can request fullscreen, via postMessage.
-  // Here, a popup window button delegates a fullscreen request to its opener.
-  window.opener.postMessage("request-fullscreen:" + screenId, { targetOrigin: window.origin, delegate: "fullscreen" });
+async function handleWindowKeyup(keyEvent) {
+  console.log(keyEvent);
+  console.log("MSW handleWindowKeyup + path:" + window.location.pathname + " key:" + (keyEvent.code === "KeyS") + " fullscreen:" + document.fullscreenElement + " popup:" + (popup && !popup.closed) + " extended:" + screen.isExtended); 
+  if (window !== window.parent && window.parent.origin === window.origin) {
+    console.log("MSW in sub-frame... let the parent handle it"); 
+    keyEvent.preventDefault();
+    window.parent.handleWindowKeyup(keyEvent);
+    return;
+  }
+
+  if (keyEvent.code === "Escape" && !["/", "/index.html"].includes(window.location.pathname)) {
+    window.close();  // Close secondary windows when pressing [Esc].
+  } else if (keyEvent.code === "KeyS" && screen.isExtended) {
+    if (popup && !popup.closed) {
+      fullscreenThisWindowAndMovePopup();
+    } else if (window.opener) {
+      fullscreenOpenerAndMoveThisPopup();
+    } else {
+      fullscreenSlideAndOpenNotesWindow();
+    }
+  }
+ }
+
+function windowOnScreen(w, s) {
+  const center = { x: w.screenLeft + w.outerWidth / 2, 
+                   y: w.screenTop + w.outerHeight / 2 };
+
+  console.log("windowOnScreen path:" + w.location.pathname + " center:" + center.x + "x" + center.y + " s: " + s.left + "," + s.top + ":" + s.width + "x" + s.height); 
+  return center.x >= s.left && (center.x < s.left + s.width) && 
+         center.y >= s.top && (center.y < s.top + s.height);
+}
+
+function waitForWindowOnScreen(w, s, resolve, reject) {
+  console.log("MSW waitForWindowOnScreen A satisfied:" + windowOnScreen(w, s)); 
+  if (!w || w.closed || !s) {
+    reject();
+  } else if (!windowOnScreen(w, s)) {
+    setTimeout(waitForWindowOnScreen.bind(this, w, s, resolve), 100);
+  } else {
+    resolve();
+  }
+}
+
+async function ensureWindowIsOnScreen(w, screenId) {
+  const screens = await getScreenDetailsWithWarningAndFallback();
+  if (!Number.isInteger(screenId) || screenId < 0 || screenId >= screens.length)
+    screenId = 0;
+  const s = screens[screenId];
+  console.log("MSW ensureWindowIsOnScreen A w:" + w + " screenId:" + screenId); 
+  return new Promise(function (resolve, reject) {
+    waitForWindowOnScreen(w, s, resolve, reject);
+  });
+}
+
+async function movePopupToScreen(p, screenId) {
+  const screens = await getScreenDetailsWithWarningAndFallback();
+  if (!Number.isInteger(screenId) || screenId < 0 || screenId >= screens.length)
+    screenId = 0;
+  const s = screens[screenId];
+
+  // Fill the target screen if the window does so on the current screen, otherwise center.
+  const fillError = 100;
+  const popupScreenDetails = await p.getScreenDetails();
+  const popupScreen = popupScreenDetails.currentScreen;
+
+  // popupScreenDetails.screens.indexOf(
+  console.log("MSW movePopupToScreen A"); // popup:" + screenId + "->" + popupTargetId + " size: " + window.outerWidth + "x" + window.outerHeight + "(" + screenDetails.currentScreen.availWidth + "x" + screenDetails.currentScreen.availHeight + ")"); 
+
+  if (Math.abs(p.outerWidth - popupScreen.availWidth) < fillError &&
+      Math.abs(p.outerHeight - popupScreen.availHeight) < fillError) {
+    console.log("MSW movePopupToScreen B fill"); 
+    p.moveTo(s.availLeft, s.availTop);
+    // Wait for the window to be moved, and then resize it to fill.
+    // screenDetails.addEventListener('currentscreenchange', async () => { 
+    //   console.log("MSW movePopupToScreen currentscreenchange");  
+    //   p.resizeTo(s.availWidth, s.availHeight); 
+    // }, { once: true }); 
+    await ensureWindowIsOnScreen(p, screenId);
+    p.resizeTo(s.availWidth, s.availHeight);
+  } else {
+    console.log("MSW movePopupToScreen C center"); 
+    const w = p.outerWidth;
+    const h = p.outerHeight;
+    // Compute coordinates centering the window on the target screen.
+    const l = s.left + Math.round(s.width - w) / 2;
+    const t = s.top + Math.round(s.height - h) / 2;
+    p.moveTo(l, t);
+  }
+}
+
+// MSW: Combine this and fullscreenSlideAndOpenNotesWindow? 
+// Make this window fullscreen on the latest popup's screen (or a fallback).
+// Also move the latest popup to another screen as needed to avoid being covered.
+async function fullscreenThisWindowAndMovePopup() {
+  // const screens = await getScreenDetailsWithWarningAndFallback(); 
+  // Make this window fullscreen on the screen hosting the latest popup and vice versa.
+  const popupScreenDetails = await popup.getScreenDetails();
+  const popupId = popupScreenDetails.screens.indexOf(popupScreenDetails.currentScreen);
+  const fullscreenId = screenDetails.screens.indexOf(screenDetails.currentScreen);
+  let fullscreenTargetId = popupId;
+  // If this window is already fullscreen, make sure the request targets another screen.
+  if (document.fullscreenElement && fullscreenTargetId == fullscreenId)
+    fullscreenTargetId = (fullscreenTargetId + 1) % screenDetails.screens.length;
+
+  const popupTargetScreen = screenDetails.currentScreen; 
+  const popupTargetScreenId = screenDetails.screens.indexOf(popupTargetScreen);
+
+  console.log("MSW fullscreenThisWindowAndMovePopup A fullscreen:" + fullscreenId + "->" + fullscreenTargetId); 
+
+  const element = document.fullscreenElement ? document.fullscreenElement : document.documentElement;
+  await toggleElementFullscreen(element, fullscreenTargetId);
+  await ensureWindowIsOnScreen(window, fullscreenTargetId);
+
+  console.log("MSW fullscreenThisWindowAndMovePopup B popup:" + popupId + "->" + popupTargetScreenId); 
+
+  // await toggleFullscreen(screenDetails.screens[screenId]);
+
+
+  // let fullscreenTargetScreen = popupScreenDetails.currentScreen;
+  // if (popupTargetscreen === fullscreenTargetScreen) {
+  //   console.log("MSW same screen swap... "); 
+  // }
+  await movePopupToScreen(popup, popupTargetScreenId);
+  await ensureWindowIsOnScreen(popup, popupTargetScreenId);
+}
+
+// Make the opener fullscreen on the target screen (or this popup's screen, or a fallback),
+// and move this popup to another screen as needed.
+async function fullscreenOpenerAndMoveThisPopup(screenId = null) {
+  const screens = await getScreenDetailsWithWarningAndFallback();
+  // This function requires multiple screens and transient user activation.
+  if (screens.length < 2 || !navigator.userActivation.isActive)
+    return;
+  // Make the opener fullscreen on the specified target screen, or this window's screen.
+  if (!Number.isInteger(screenId) || screenId < 0 || screenId >= screens.length)
+    screenId = screens.indexOf(screenDetails.currentScreen);
+  const openerScreenDetails = await opener.getScreenDetails();
+  const openerId = openerScreenDetails.screens.indexOf(openerScreenDetails.currentScreen);
+  // If the opener is already fullscreen, make sure the request targets another screen.
+  if (opener.document.fullscreenElement)
+    screenId = (openerId == screenId) ? ((screenId + 1) % screens.length) : screenId;
+  console.log("MSW fullscreenOpenerAndMoveThisPopup A fullscreen:" + openerId + "->" + screenId); 
+
+  // screenId 
+
+  // Delegate this window's transient user activation so the opener can request fullscreen.
+  window.opener.postMessage("request-fullscreen:" + screenId,
+                            { targetOrigin: window.origin, delegate: "fullscreen" });
+  // Move this window to another screen if the opener will be made fullscreen on its current screen.
+  if (screens[screenId] === screenDetails.currentScreen) {
+    // // Wait for the opener to actually move to the target screen.
+    // openerScreenDetails.addEventListener('currentscreenchange', async () => {
+      // MSW: Wait for the window bounds to actually reflect placement on the target screen. 
+      await ensureWindowIsOnScreen(window.opener, screenId);
+
+      // Move to the opener's original screen, or the next available screen.
+      const popupTargetScreenId = (openerId == screenId) ? ((screenId + 1) % screens.length) : openerId;
+      await movePopupToScreen(window, popupTargetScreenId);
+      await ensureWindowIsOnScreen(window, popupTargetScreenId);
+
+    // }, { once: true });
+  }
 }

--- a/notes.html
+++ b/notes.html
@@ -21,10 +21,10 @@ textarea { width:99%; height:99%; border-radius: 5px; }
 .notes { grid-column: 2; grid-row: 2; }
 </style>
 
+<script src="main.js"></script>
 <script>
 'use strict';
 window.addEventListener('load', () => {
-  window.addEventListener('keyup', (e) => { if (e.key === "Escape") window.close(); });
   let timer = 0;
   setInterval(() => {
     let pad = (i) => { return (i < 10 ? "0" : "") + i; }

--- a/popup.html
+++ b/popup.html
@@ -38,7 +38,7 @@ window.addEventListener('load', () => {
 
   // Handle control button clicks and input events.
   updateScreensButton.addEventListener('click', updateScreens);
-  fullscreenOpenerButton.addEventListener('click', fullscreenOpenerAndDodge);
+  fullscreenOpenerButton.addEventListener('click', fullscreenOpenerAndMoveThisPopup);
   moveToButton.addEventListener('click', () => {
     window.moveTo(moveToLeftInput.value, moveToTopInput.value);
     updateScreens(/*requestPermission=*/false);

--- a/popup.html
+++ b/popup.html
@@ -31,8 +31,6 @@
 <script>
 'use strict';
 window.addEventListener('load', () => {
-  window.addEventListener('keyup', (e) => { if (e.key === "Escape") window.close(); });
-
   moveToLeftInput.value = window.screenLeft;
   moveToTopInput.value = window.screenTop;
   resizeToWidthInput.value = window.outerWidth;
@@ -40,7 +38,7 @@ window.addEventListener('load', () => {
 
   // Handle control button clicks and input events.
   updateScreensButton.addEventListener('click', updateScreens);
-  fullscreenOpenerButton.addEventListener('click', fullscreenOpener);
+  fullscreenOpenerButton.addEventListener('click', fullscreenOpenerAndDodge);
   moveToButton.addEventListener('click', () => {
     window.moveTo(moveToLeftInput.value, moveToTopInput.value);
     updateScreens(/*requestPermission=*/false);

--- a/slide.html
+++ b/slide.html
@@ -26,13 +26,6 @@
 </pre>
 </div>
 </div>
-
-<script>
-'use strict';
-window.addEventListener('load', () => {
-  window.addEventListener('keyup', (e) => { if (e.key === "Escape") window.close(); });
-});
-</script>
-
+<script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Extend demo support for new features (trigger via "s" key or new "Fullscreen opener" popup button):
- Fullscreen Companion Window - https://chromestatus.com/feature/5173162437246976)
  - Requesting fullscreen and opening a popup from a single user activation
- Fullscreen Capability Delegation - https://chromestatus.com/feature/6441688242323456)
  - The popup can relinquish a transient user activation to delegate a fullscreen request to its opener
- Swapping the screens of a fullscreen opener and a popup from one user activation in either window
  - Works from the fullscreen window with base API support; works from the popup with fullscreen delegation

These features require (or work best with) Chrome M103+ using these command line switches:
$ chrome --enable-blink-features=CapabilityDelegationFullscreenRequest --enable-features=WindowPlacementFullscreenCompanionWindow
(required for opening a popup after requesting fullscreen, and delegating fullscreen [swap] from the popup)

Track the latest popup created via openWindow() and use that for slide and notes popups.
Add helpers to move popups, delegate fullscreen (and ack), await expected placements.
Load main.js on auxiliary pages; centralize key event handling; add conditionals and early returns; misc cleanup.

FYI @bradtriebwasser, @cterefinko, @mustaqahmed, @tomayac (no action needed, but feedback is appreciated)