### PR TITLE
Prevent [s] from opening fullscreen+companion window on home page

### DIFF
--- a/main.js
+++ b/main.js
@@ -309,12 +309,14 @@ async function handleWindowKeyup(keyEvent) {
     window.parent.handleWindowKeyup(keyEvent);
     return;
   }
+  
+  const isHome = ["/index.html", "/window-placement-demo/"].includes(window.location.pathname);
 
-  if (keyEvent.code === "Escape" && !["/index.html", "/window-placement-demo/"].includes(window.location.pathname)) {
+  if (keyEvent.code === "Escape" && !isHome) {
     window.close();  // Close auxiliary windows on [Esc].
   } else if (keyEvent.code === "Enter" && openWindowControls && openWindowControls.contains(keyEvent.target)) {
     openWindow();  // Open a window when on [Enter] targeting an "Open window" input element.
-  } else if (keyEvent.code === "KeyS" && screen.isExtended) {
+  } else if (keyEvent.code === "KeyS" && screen.isExtended && !isHome) {
     // Initiate a fullscreen + popup multi-screen experience, or swap their screens on [s].
     if (popup && !popup.closed)
       fullscreenThisWindowAndMovePopup();


### PR DESCRIPTION
Pressing [s] should only swap when not on the home page. Otherwise pressing [s] on the home page opens the fullscreen and companionwindow again if they are not already open.